### PR TITLE
Deployment: mutable environment

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,6 +15,8 @@ $app = new Illuminate\Foundation\Application(
 	realpath(__DIR__.'/../')
 );
 
+Dotenv::makeMutable();
+
 /*
 |--------------------------------------------------------------------------
 | Bind Important Interfaces


### PR DESCRIPTION
Not sure why laravel doesn't do this by default, but in order to make the site run in 'prod' environment and the beta site to run on 'development' environment I have to make the app Dotenv mutable.

Re #258

Signed-off-by: Jesus Fernandez jesus.fndz@gmail.com
