### PR TITLE
Fix an issue with the startup search

### DIFF
--- a/app/Repositories/StartupRepository.php
+++ b/app/Repositories/StartupRepository.php
@@ -118,7 +118,8 @@ class StartupRepository
 		$paginatedResults = $results->paginate($perPage);
 
 		if ($needs or $tags) {
-			$paginatedResults->appends(['needs' => $needs, 'tags' => implode($tags, ',')]);
+			$tags = is_array($tags) ? implode($tags, ',') : '';
+			$paginatedResults->appends(['needs' => $needs, 'tags' => $tags]);
 		}
 
 		return $paginatedResults;


### PR DESCRIPTION
An empty tags list couldn't and shouldn't be imploded.

Re #261
